### PR TITLE
chore: remove committed binary, fix docs/gitignore/prune scoping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-honeycomb.zsh
-aws-sso.zsh

--- a/README.md
+++ b/README.md
@@ -1,61 +1,62 @@
-# skr1pts
+# skr1ptz
 
-Custom shell configuration and utility scripts by [@und1sk0](https://github.com/und1sk0).  
+Custom shell configuration and utility scripts by [@und1sk0](https://github.com/und1sk0).
 
-This repository provides a highly-opinionated `.zshrc` setup tailored for **macOS (Intel & Apple Silicon)** with useful defaults, security-minded git helpers, AWS shortcuts, and quality-of-life functions for everyday development and operations work.  
+This repository provides a highly-opinionated `.zshrc` setup tailored for **macOS (Intel & Apple Silicon)** with useful defaults, security-minded git helpers, AWS shortcuts, and quality-of-life functions for everyday development and operations work.
 
 ---
 
 ## ✨ Features
 
-- **Oh-My-Zsh Base** with randomized themes, Git plugin, and `vi` mode.  
-- **macOS Path Handling**  
-  - Dynamically adjusts `$PATH` for macOS Sonoma (14.x) and Sequoia (15.x).  
-  - Adds Apple Silicon support with `/opt/homebrew/bin`.  
-- **Convenient Aliases**  
-  - Shortcuts for Git, Terraform (`tfa`, `tfp`, etc.), Kubernetes (`k`, `kd`, `kp`), and system tools.  
-  - `vz` to edit and reload `.zshrc` instantly.  
-- **Git Safety Nets**  
-  - `gp` and `gpsup` prevent accidental pushes to `main` or `master`.  
-  - `prune` helper cleans up stale local branches (with optional `-f` for force delete).  
-- **AWS Utilities**  
-  - `ssm` helper for starting AWS SSM sessions.  
-  - Default AWS profile set to `default`.  
-- **System Enhancements**  
-  - Syntax highlighting for `less` output.  
-  - `fm` to extract ffmpeg metadata.  
-  - Colorized diffs with `colordiff`.  
-- **Plugin Support**  
-  - Bundles [`zi`](https://github.com/z-shell/zi) plugin manager for Zsh.  
-  - Auto-sources additional configs from `$HOME/.zshconfig/*.zsh`.  
-- **Rancher Desktop Integration** — automatically manages its PATH.  
+- **Oh-My-Zsh Base** with randomized themes, Git plugin, and `vi` mode.
+- **PATH Handling**
+  - Base system paths, plus Homebrew prepended by chip architecture (`arm64` → `/opt/homebrew/bin`), not macOS version.
+  - Deduplicates `$PATH` on every shell start.
+- **Convenient Aliases**
+  - Shortcuts for Git, Terraform (`tfa`, `tfp`, etc.), Kubernetes (`k`, `kd`, `kp`), and system tools.
+  - `rgr` for recursive grep (`rg` is left free for ripgrep).
+  - `vz` to edit and reload `.zshrc` instantly.
+- **Git Safety Nets**
+  - `gp` and `gpsup` prevent accidental pushes to `main` or `master`.
+  - `prune` cleans up local branches whose remote tracking branch is gone (`-f` to force-delete unmerged ones); hops off the current branch first if it's one of the stale ones.
+- **AWS Utilities**
+  - `ssm` helper for starting AWS SSM sessions.
+  - Default AWS profile set to `default`.
+- **System Enhancements**
+  - Syntax highlighting for `less` output.
+  - `fm` to extract ffmpeg metadata.
+  - Colorized diffs with `colordiff`.
+- **Plugin Support**
+  - Bundles [`zi`](https://github.com/z-shell/zi) plugin manager for Zsh.
+  - Auto-sources additional configs from `$HOME/.zshconfig/*.zsh`.
+- **Rancher Desktop Integration** — automatically manages its PATH.
 
 ---
 
 ## 🚀 Installation
 
-Clone this repo and link the `.zshrc` into your home directory:  
+The real config lives at `zshrc.zsh` in this repo. The actual setup on this
+machine wires it in via two symlinks rather than a plain copy, so edits here
+take effect immediately without re-installing anything:
 
 ```bash
-git clone https://github.com/und1sk0/skr1pts.git ~/skr1pts
-cp ~/skr1pts/.zshrc ~/.zshrc
+ln -s ~/git/skr1ptz ~/bin
+ln -s bin/zshrc.zsh ~/.zshrc
 source ~/.zshrc
 ```
 
-> ⚠️ This will override your existing `~/.zshrc`. Back it up first if you need to preserve custom settings.  
-
----
+> ⚠️ This will override your existing `~/.zshrc`. Back it up first if you need to preserve custom settings.
 
 ## 🛠 Usage Highlights
 
-- **Safe Git Push**  
+- **Safe Git Push**
   ```bash
   gp     # push current branch (fails if on main/master)
   gpsup  # push and set upstream (fails if on main/master)
-  prune  # delete local branches with no remote tracking
+  prune  # delete local branches with no remote tracking (-f to force)
   ```
 
-- **Terraform**  
+- **Terraform**
   ```bash
   tfi   # terraform init
   tfp   # terraform plan
@@ -64,14 +65,14 @@ source ~/.zshrc
   tff   # terraform fmt
   ```
 
-- **Kubernetes Contexts**  
+- **Kubernetes Contexts**
   ```bash
   k     # kubectl
   kd    # use dev context
   kp    # use prod context
   ```
 
-- **AWS**  
+- **AWS**
   ```bash
   ssm i-1234567890abcdef0   # start SSM session
   ```
@@ -80,16 +81,10 @@ source ~/.zshrc
 
 ## 📂 Extending
 
-Place custom Zsh configs in `~/.zshconfig/*.zsh` and they will be automatically sourced on startup.  
+Place custom Zsh configs in `~/.zshconfig/*.zsh` and they will be automatically sourced on startup.
 
 ---
 
 ## 🧑‍💻 Maintainer
 
-[**und1sk0**](https://github.com/und1sk0)  
-
----
-
-## 📜 License
-
-MIT License © und1sk0  
+[**und1sk0**](https://github.com/und1sk0)

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -104,7 +104,7 @@ function prune() {
 
     # `git branch -vv` marks the checked-out branch with a leading "* " instead of
     # two spaces, which shifts $1 to the literal "*" for that line — strip it first.
-    local_stale_branches=("${(@f)$(git branch -vv | awk '/origin\/.*: gone]/ {sub(/^\* /, ""); print $1}')}")
+    local local_stale_branches=("${(@f)$(git branch -vv | awk '/origin\/.*: gone]/ {sub(/^\* /, ""); print $1}')}")
 
     if [[ -z "$local_stale_branches" ]]; then
         echo "No stale branches to delete."


### PR DESCRIPTION
## Summary
- Remove `code`, an accidentally-committed compiled binary with no references anywhere in the repo (still in history under old commits — say the word if a full history purge is wanted too)
- Rewrite README: fix repo name typo (`skr1pts` -> `skr1ptz`), correct install instructions to match the actual symlink setup (`~/bin` -> this repo, `~/.zshrc` -> `bin/zshrc.zsh`), fix the PATH description (chip architecture, not macOS version, per the `fix/path` merge), and drop the MIT license claim since no `LICENSE` file exists
- Remove two `.gitignore` entries (`honeycomb.zsh`, `aws-sso.zsh`) confirmed via git history to have never been tracked files
- Declare `local_stale_branches` as `local` in `prune()` — every other variable in that function already was; this one was leaking into global shell scope on every call

Also fixed locally (not part of this diff, since the file isn't tracked by git): `.claude/settings.local.json` had a blanket `Bash(git push:*)` auto-allow that silently bypassed the `git_safe_push`/`gp` guard this repo defines — removed so pushes go through a confirmation prompt again.

## Test plan
- [x] `zsh -n zshrc.zsh` syntax check passes
- [x] Confirmed via `git log --all -- honeycomb.zsh aws-sso.zsh` that those files were never tracked, so removing the gitignore entries is safe
- [x] Confirmed via `git grep` that no other file references the `skr1pts` typo