### PR TITLE
feat(zshrc): add claude and zshconfig-reload aliases, fix Rancher path

### DIFF
--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -29,7 +29,7 @@ export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
 export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 
 ### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)
-export PATH="/Users/und1sk0/.rd/bin:$PATH"
+export PATH="$HOME/.rd/bin:$PATH"
 ### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)
 
 # Deduplicate PATH
@@ -40,7 +40,7 @@ alias apwhois="whois -h whois.apnic.net"
 alias awhois="whois -h whois.arin.net"
 alias c="curl -sq"
 alias cg="cd ~/git"
-alias cow="ssh noise@happy.cow.org."
+alias claudia="claude"
 alias diff="colordiff"
 alias gres="gco main && gl"
 alias h="history | grep "
@@ -62,6 +62,7 @@ alias v="vim"
 alias vax="find . \( -name '*.yaml' -o -name '*.json' -o -name '*.txt' -o -name '*.log' \) -print0 | xargs -0 xattr -d com.apple.quarantine 2>/dev/null"
 alias vz="vim ~/.zshrc && source ~/.zshrc"
 alias z="source ~/.zshrc"
+alias zc="source ~/.zshconfig/*.zsh"
 
 ## Functions
 


### PR DESCRIPTION
## Summary
- Add `claudia` alias for `claude`, and `zc` to reload `~/.zshconfig/*.zsh` without a full shell restart.
- Drop the unused `cow` alias.
- Fix the Rancher Desktop PATH block to use `$HOME` instead of a hardcoded `/Users/und1sk0` path, so it works on other machines.

## Test plan
- [ ] `source zshrc.zsh` and confirm `claudia`, `zc`, `diff` (colordiff) aliases resolve as expected.
- [ ] Confirm `$HOME/.rd/bin` is on `$PATH` after sourcing, on a machine with Rancher Desktop installed.