### PR TITLE
fix(zshrc): fall back to master if main doesn't exist in gres

### DIFF
--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -42,7 +42,6 @@ alias c="curl -sq"
 alias cg="cd ~/git"
 alias claudia="claude"
 alias diff="colordiff"
-alias gres="gco main && gl"
 alias h="history | grep "
 alias k="kubectl"
 alias kd="kubectl config use-context dev"
@@ -91,6 +90,11 @@ function git_safe_push_upstream() {
 
 alias gp='git_safe_push'
 alias gpsup='git_safe_push_upstream'
+
+function gres() {
+    gco main 2>/dev/null || gco master
+    gl
+}
 
 function prune() {
     local delete_arg="-d"


### PR DESCRIPTION
## Summary
- `gres` now tries `gco main` first and falls back to `gco master` if `main` doesn't exist, before running `gl`.

## Test plan
- [ ] In a repo whose default branch is `main`, run `gres` and confirm it checks out `main` and pulls.
- [ ] In a repo whose default branch is `master`, run `gres` and confirm it falls back to `master` and pulls.